### PR TITLE
Fix Warning in lib/yrewrite/yrewrite.php:222

### DIFF
--- a/lib/yrewrite/yrewrite.php
+++ b/lib/yrewrite/yrewrite.php
@@ -219,7 +219,7 @@ class rex_yrewrite
     {
         if (rex::isFrontend() && 'get' === rex_request_method() && !rex_get('rex-api-call') && $articleId = rex_get('article_id', 'int')) {
             $params = $_GET;
-            $article = rex_article::get((int) $params['article_id'], (int) $params['clang'] ?: rex_clang::getCurrentId());
+            $article = rex_article::get((int) $params['article_id'], (int) ($params['clang'] ?? 0) ?: rex_clang::getCurrentId());
             if ($article instanceof rex_article) {
                 unset($params['article_id']);
                 unset($params['clang']);


### PR DESCRIPTION
Aus irgendwelchen Gründen ist bei einigen Leuten $params['clang'] nicht gesetzt und erzeugt dann die bereits in #544 geschilderte Warning.
Der alte Fix (?:) verhindert die Warning nicht, es muss schon "??" sein.