### PR TITLE
Startsprache-Auto und Startsprache-Hidden als Kombi verhindern

### DIFF
--- a/lib/yrewrite/domain.php
+++ b/lib/yrewrite/domain.php
@@ -44,7 +44,7 @@ class rex_yrewrite_domain
         $this->notfoundId = $notfoundId;
         $this->clangs = null === $clangs ? rex_clang::getAllIds() : $clangs;
         $this->startClang = $startClang;
-        $this->startClangAuto = $startClangAuto;
+        $this->startClangAuto = $startClangAuto && !$startClangHidden;
         $this->startClangHidden = $startClangHidden;
         $this->title = $title;
         $this->description = $description;

--- a/pages/domains.php
+++ b/pages/domains.php
@@ -40,28 +40,28 @@ if ('' != $func) {
     $yform->setValidateField('empty', ['notfound_id', $this->i18n('no_not_found_id_defined')]);
 
     $yform->setValueField('choice', ['clangs', $this->i18n('clangs'), 'select id, name from '.rex::getTable('clang'), 0, 1, '', '', '', '', '', '', '', '<small>'.$this->i18n('clangs_info').'</small>']);
-    $yform->setValueField('checkbox', ['clang_start_auto', $this->i18n('clang_start_auto')]);
     $yform->setValueField('choice', ['clang_start', $this->i18n('clang_start'), 'select id, name from '.rex::getTable('clang'), 0, 0, '', '', '', '', '', '', '', '<small>'.$this->i18n('clang_start_info').'</small>']);
-    $yform->setValueField('checkbox', ['clang_start_hidden', $this->i18n('clang_start_hidden')]);
+    $yform->setValueField('checkbox', ['clang_start_hidden', $this->i18n('clang_start_hidden'), 'attributes' => ['data-yrewrite-clang-start-hidden' => '1']]);
+    $yform->setValueField('checkbox', ['clang_start_auto', $this->i18n('clang_start_auto'), 'attributes' => ['data-yrewrite-clang-start-auto' => '1']]);
     $yform->setValueField('text', ['title_scheme', $this->i18n('domain_title_scheme'), rex_yrewrite_seo::$title_scheme_default, 'notice' => '<small>'.$this->i18n('domain_title_scheme_info').'</small>']);
     $yform->setValueField('checkbox', ['auto_redirect', $this->i18n('auto_redirects'), 'notice' => '<small>'.$this->i18n('yrewrite_auto_redirect').'</small>']);
     $yform->setValueField('text', ['auto_redirect_days', $this->i18n('yrewrite_auto_redirect_days'), 'notice' => '<small>'.$this->i18n('yrewrite_auto_redirect_days_info').'</small>']);
 
     $js = '
-        <script>
+        <script nonce="' . rex_response::getNonce() . '">
             (function () {
-                var startClangAuto = document.getElementById(\'yform-yrewrite_domains_form-field-10\');
-                var startClangHidden = document.getElementById(\'yform-yrewrite_domains_form-field-12\');
+                var startClangAuto = document.querySelector(\'[data-yrewrite-clang-start-auto]\');
+                var startClangHidden = document.querySelector(\'[data-yrewrite-clang-start-hidden]\');
 
-                startClangAuto.addEventListener("change", function () {
-                    if (startClangAuto.checked) {
-                        startClangHidden.disabled = true;
-                        startClangHidden.checked = false;
+                startClangHidden.addEventListener("change", function () {
+                    if (startClangHidden.checked) {
+                        startClangAuto.disabled = true;
+                        startClangAuto.checked = false;
                     } else {
-                        startClangHidden.disabled = false;
+                        startClangAuto.disabled = false;
                     }
                 });
-                startClangAuto.dispatchEvent(new Event("change"));
+                startClangHidden.dispatchEvent(new Event("change"));
             })();
         </script>
     ';


### PR DESCRIPTION
fixes #565, closes #591

Ich finde die Variante in #591 nicht sinnvoll. Eigentlich hatten wir sogar schon Javascript, welches die Kombination beider Optionen verhindern sollte. Das funktionierte aber nicht mehr.
Habe ich repariert und die Abhängigkeit aber umgedreht (und daher auch die Anordnung der Checkboxen).

Und neu wird es aber auch in PHP abgefangen, damit es wirklich nicht mehr zu der Endlosweiterleitung kommt.