### PR TITLE
Fix warning: Deprecated: trim(): Passing null to parameter #1

### DIFF
--- a/lib/yrewrite/seo.php
+++ b/lib/yrewrite/seo.php
@@ -174,7 +174,7 @@ class rex_yrewrite_seo
 
     public function getCanonicalUrl()
     {
-        $canonical_url = trim($this->article->getValue(self::$meta_canonical_url_field));
+        $canonical_url = trim($this->article->getValue(self::$meta_canonical_url_field) ?? '');
         if ('' == $canonical_url) {
             $canonical_url = rex_yrewrite::getFullUrlByArticleId($this->article->getId(), $this->article->getClangId());
         }


### PR DESCRIPTION
Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in src/addons/yrewrite/lib/yrewrite/seo.php on line 177

fixes #570
(finally), other already fixed